### PR TITLE
[M2] Updated search functionality to extract and display keywords from links

### DIFF
--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -37,7 +37,6 @@ class WebpageSearcher:
         similarities = {}
 
         for link in self.links:
-            print("*** iteration")
             processed_link = preprocess_webpage(link)
             similarity = calculate_similarity(processed_query, processed_link)
             similarities[link] = similarity
@@ -104,30 +103,13 @@ def tag_visible(element):
     return True
 
 def get_keywords(query, keywords_model):
-    # # using rake-nlkt
-    # # Create rake object to extract the top keywords from query
-    # rake_object = Rake(min_length = KEYWORD_PHRASE_MIN_SIZE, max_length = KEYWORD_PHRASE_MAX_SIZE, include_repeated_phrases = False)
-    # rake_object.extract_keywords_from_text(query)
-    # top_keywords = rake_object.get_ranked_phrases()[:TOP_N_KEYWORDS]
-    #
-    # # Return top keywords as string separated by commas
-    # return ', '.join(top_keywords)
-
-    # using multi-rake
-    # Create rake object to extract the top keywords from query
-    rake_object = Rake( max_words = KEYWORD_PHRASE_MAX_SIZE)
-    keywords = rake_object.apply(query)
-    top_keywords= list(dict(keywords).keys())[:TOP_N_KEYWORDS]
+    #using the keybert package, extract top keywords from query
+    top_keywords = keywords_model.extract_keywords(query, 
+                                     keyphrase_ngram_range = (KEYWORD_PHRASE_MIN_SIZE, KEYWORD_PHRASE_MAX_SIZE), 
+                                     highlight = False,
+                                     top_n = TOP_N_KEYWORDS)
+    keywords_list= list(dict(top_keywords).keys())
 
     # Return top keywords as string separated by commas
-    return ', '.join(top_keywords)
-
-    #using keybert
-    # top_keywords = keywords_model.extract_keywords(query, 
-    #                                  keyphrase_ngram_range = (KEYWORD_PHRASE_MIN_SIZE, KEYWORD_PHRASE_MAX_SIZE), 
-    #                                  highlight = False,
-    #                                  top_n = TOP_N_KEYWORDS)
-    # keywords_list= list(dict(top_keywords).keys())
-    # Return top keywords as string separated by commas
-    # return ', '.join(keywords_list)
+    return ', '.join(keywords_list)
 

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -1,14 +1,11 @@
 import nltk
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
-from rake_nltk import Rake
 from bs4 import BeautifulSoup
 import requests
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
-# from summa import keywords
 from keybert import KeyBERT
-from multi_rake import Rake
 
 nltk.download('punkt')
 nltk.download('stopwords')
@@ -110,4 +107,3 @@ def get_keywords(query, keywords_model):
 
     # Return top keywords as string separated by commas
     return ', '.join(keywords_list)
-

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -1,6 +1,7 @@
 import nltk
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
+from rake_nltk import Rake
 from bs4 import BeautifulSoup
 import requests
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -9,6 +10,8 @@ from sklearn.metrics.pairwise import cosine_similarity
 nltk.download('punkt')
 nltk.download('stopwords')
 nltk.download('wordnet')
+
+TOP_N_KEYWORDS = 4
 
 class WebpageSearcher:
     def __init__(self):
@@ -25,18 +28,21 @@ class WebpageSearcher:
         similarities = {}
         for link in self.links:
             processed_link = preprocess_webpage(link)
+            link_keywords = get_keywords(processed_link)
             similarity = calculate_similarity(processed_query, processed_link)
-            similarities[link] = similarity
+            similarities[(link, link_keywords)] = similarity
 
         # Find the link with the highest similarity
-        sorted_links = sorted(similarities, key=similarities.get, reverse=True)
-        most_similar_link = sorted_links[0]
+        sorted_links_with_keywords = sorted(similarities, key=similarities.get, reverse=True)
+        most_similar_link_with_keywords = sorted_links_with_keywords[0]
+        print("###############", most_similar_link_with_keywords)
 
         # Return the most similar link, or "no result" if no matching link is found
-        if similarities[most_similar_link] == 0:
-            return "no result"
+        if similarities[most_similar_link_with_keywords] == 0:
+            return "no result", ""
         else:
-            return most_similar_link
+            # Get keywords as string
+            return most_similar_link_with_keywords
 
 def preprocess_text(text):
     # Tokenize the text into words
@@ -85,3 +91,14 @@ def tag_visible(element):
     if element.parent.name in ['style', 'script', 'head', 'title', 'meta', '[document]']:
         return False
     return True
+
+def get_keywords(query):
+    # Create rake object to extract the top keywords from query
+    rake_object = Rake()
+    rake_object.extract_keywords_from_text(query)
+    top_keywords = rake_object.get_ranked_phrases()[:TOP_N_KEYWORDS]
+
+    # Return top keywords as string separated by commas
+    print("!!!!!", top_keywords)
+    return ', '.join(top_keywords)
+

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -22,9 +22,7 @@ KEYWORD_PHRASE_MAX_SIZE = 2
 class WebpageSearcher:
     def __init__(self):
         self.links = []
-        print("start\n")
         self.keywords_model = KeyBERT(model='all-mpnet-base-v2')
-        print("end\n")
 
     def add_link(self, link):
         self.links.append(link)

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -36,11 +36,11 @@ def search(request):
    query = request.GET.get('q', '')
    result = ""
    if query != '':
-      url = searcher.search(query)
+      url, keywords = searcher.search(query)
       if url is None or url == "no result":
          result = "No matches found"
       else:
-         result = "Closest match: " + url
+         result = "Closest match: " + url + "\n Keywords: " + keywords
    return render(request, 'search.html', {
       "result" : result,
    })

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -34,15 +34,20 @@ searcher.add_link("https://www.hbc.bank/11-ways-to-check-if-a-website-is-legit-o
 def search(request):
    # TODO: This should be made async
    query = request.GET.get('q', '')
-   result = ""
+   
+   url_result = ""
+   keywords_result = ""
    if query != '':
       url, keywords = searcher.search(query)
       if url is None or url == "no result":
-         result = "No matches found"
+         url_result = "No matches found"
       else:
-         result = "Closest match: " + url + "\n Keywords: " + keywords
+         url_result = url
+         keywords_result = keywords
+
    return render(request, 'search.html', {
-      "result" : result,
+      "url_result" : url_result,
+      "keywords_result" : keywords_result,
    })
 
 @login_required

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -47,3 +47,5 @@ webencodings==0.5.1
 whitenoise==6.0.0
 wrapt==1.11.1
 rake-nltk==1.0.6
+keybert==0.7.0
+multi-rake==0.0.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -46,6 +46,4 @@ WeasyPrint==47
 webencodings==0.5.1
 whitenoise==6.0.0
 wrapt==1.11.1
-rake-nltk==1.0.6
 keybert==0.7.0
-multi-rake==0.0.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,10 +20,10 @@ html5lib==1.0.1
 idna==2.8
 isort==4.3.17
 lazy-object-proxy==1.3.1
-lxml==4.9.1
+# lxml==4.9.1
 mccabe==0.6.1
 nltk==3.8.1
-psycopg2-binary==2.8.1
+# psycopg2-binary==2.8.1
 pycodestyle==2.5.0
 pycparser==2.19
 pydocusign==2.2
@@ -46,3 +46,4 @@ WeasyPrint==47
 webencodings==0.5.1
 whitenoise==6.0.0
 wrapt==1.11.1
+rake-nltk==1.0.6

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -32,10 +32,12 @@
         <div class="logo">
             <img alt="Google" src="{% static 'helpdesk_app/img/logo.png' %}">
         </div>
-        {% if result != '' %}
+        {% if url_result != '' %}
             <div class="search_result">
                 <h2>Result</h2>
-                {{ result }}
+                <b>Closest Match: </b><a href="{{ url_result }}" target="_blank">{{ url_result }}</a>
+                <br/>
+                <b>Keywords: </b>{{ keywords_result }}
                 <br/>
                 <br/>
                 <a href="{% url 'home' %}">Try another search...</a>


### PR DESCRIPTION
Fixes #18. This PR implements extracting keywords from links and also displays them.

Note: for some reason, I wasn't able to install `lxml==4.9.1` and `psycopg2-binary==2.8.1` from the `requirements.txt` file, I commented them out and everything worked well.

I explored multiple packages, and out of the ones I got to work (keybert, multi-rake, rake-nltk, https://github.com/LIAAD/yake), keybert had the best results but was the slowest. 

Under the "explored different keyword packages" commit, other implementations can be seen.
