### PR TITLE
[M2] Set up CI for Github repo (testing, linter)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Run helpdesk tests
+on: [pull_request, push]
+jobs:
+  test_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+      - run: pip install flake8==4.0.0
+      - run: pip install -r src/requirements.txt # Install all project dependencies
+      - run: cd src && python manage.py test # Run Django tests
+      - run: flake8 src/helpdesk_app # Run flake8 linter
+      - run: flake8 src/helpdesk_proj # Run flake8 linter
+      - run: flake8 src/SearchEngine # Run flake8 linter

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,10 +20,8 @@ html5lib==1.0.1
 idna==2.8
 isort==4.3.17
 lazy-object-proxy==1.3.1
-lxml==4.9.1
 mccabe==0.6.1
 nltk==3.8.1
-psycopg2-binary==2.8.1
 pycodestyle==2.5.0
 pycparser==2.19
 pydocusign==2.2
@@ -33,7 +31,6 @@ python-dateutil==2.8.0
 python-decouple==3.3
 py-trello==0.18.0
 pytz==2019.1
-reportlab==3.6.1
 requests==2.21.0
 scikit-learn==1.2.1
 six==1.16.0


### PR DESCRIPTION
This pull-request fixes #31, and:
- Adds a new Github Action that will automatically run the Django tests stored in the `tests` directory, and runs the `flake8` linter on our application & project directory code
- Removes dependencies from `requirements.txt` that are also problematic (failing to install on Github's ubuntu testing machines)

<img width="999" alt="Screen Shot 2023-03-15 at 8 38 25 PM" src="https://user-images.githubusercontent.com/28874539/225479893-98c3fdfb-fc7a-47d5-9784-01d5a4c624c8.png">

With the addition of the linter, we can also see that a lot of our code's files are not meeting proper style requirements. A new issue (#32) has been opened to address this in a future PR. For the meantime, our CI will show as "failed" until the files are style-compliant.

<img width="1069" alt="Screen Shot 2023-03-15 at 8 38 52 PM" src="https://user-images.githubusercontent.com/28874539/225479910-e690491b-596f-4045-803e-964a8d0d68a5.png">
