### PR TITLE
[M5] Autocomplete with category (fixes #67, #74)

### DIFF
--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -83,7 +83,7 @@ def autocomplete_search(request):
     if 'term' in request.GET:
         query = request.GET.get('term')
         category = request.GET.get('c', '')
-        # if not category was actually selected
+        # if no category was actually selected
         if category == "Category search" or category == "Categoría":
             category = ""
         autocomplete_results = None

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -83,9 +83,7 @@ def autocomplete_search(request):
     if 'term' in request.GET:
         query = request.GET.get('term')
         category = request.GET.get('c', '')
-        # if no category was actually selected
-        if category == "Category search" or category == "Categoría":
-            category = ""
+
         autocomplete_results = None
         category_object = None
         if category != '':

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -27,7 +27,6 @@ logger.info("core.views logger")
 searcher = WebpageSearcher()
 AUTOCOMPLETE_MAX_RESULTS = 5
 FAQ_MAX_RESULTS = 5
-AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH = 40
 ##############################
 
 
@@ -102,10 +101,7 @@ def autocomplete_search(request):
                 if category != '':
                     autocomplete_results = [resource for resource in autocomplete_results if category_object in list(resource.categories.all())]
         for resource in autocomplete_results:
-            if len(resource.title) > AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH:
-                titles.append(resource.title[:AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH] + "...")
-            else:
-                titles.append(resource.title)
+            titles.append(resource.title)
     return JsonResponse(titles[:AUTOCOMPLETE_MAX_RESULTS], safe=False)
 
 

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -83,6 +83,9 @@ def autocomplete_search(request):
     if 'term' in request.GET:
         query = request.GET.get('term')
         category = request.GET.get('c', '')
+        # if not category was actually selected
+        if category == "Category search" or category == "Categoría":
+            category = ""
         autocomplete_results = None
         category_object = None
         if category != '':
@@ -95,9 +98,10 @@ def autocomplete_search(request):
             if not len(autocomplete_results):
                 # Using just the title if no results came from the seracher
                 autocomplete_results = AnswerResource.objects.filter(title__icontains=query)
-
+                if category != '':
+                    autocomplete_results = [resource for resource in autocomplete_results if category_object in list(resource.categories.all())]
         for resource in autocomplete_results:
-            titles.append(resource.title)
+                titles.append(resource.title)
     return JsonResponse(titles[:AUTOCOMPLETE_MAX_RESULTS], safe=False)
 
 

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -26,7 +26,7 @@ logger.info("core.views logger")
 # Search model
 searcher = WebpageSearcher()
 AUTOCOMPLETE_MAX_RESULTS = 5
-FAQ_MAX_RESULTS = 5
+AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH = 40
 ##############################
 
 
@@ -101,6 +101,9 @@ def autocomplete_search(request):
                 if category != '':
                     autocomplete_results = [resource for resource in autocomplete_results if category_object in list(resource.categories.all())]
         for resource in autocomplete_results:
+            if len(resource.title) > AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH:
+                titles.append(resource.title[:AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH] + "...")
+            else:
                 titles.append(resource.title)
     return JsonResponse(titles[:AUTOCOMPLETE_MAX_RESULTS], safe=False)
 

--- a/src/helpdesk_app/views.py
+++ b/src/helpdesk_app/views.py
@@ -26,6 +26,7 @@ logger.info("core.views logger")
 # Search model
 searcher = WebpageSearcher()
 AUTOCOMPLETE_MAX_RESULTS = 5
+FAQ_MAX_RESULTS = 5
 AUTOCOMPLETE_RESOURCE_TITLE_MAX_LENGTH = 40
 ##############################
 

--- a/src/helpdesk_proj/static/helpdesk_app/css/jquery-ui.css
+++ b/src/helpdesk_proj/static/helpdesk_app/css/jquery-ui.css
@@ -60,7 +60,8 @@
 .ui-state-default a, .ui-state-default a:link, .ui-state-default a:visited { color: #1c94c4; text-decoration: none; }
 .ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus { border: 1px solid #fbcb09; background: #fdf5ce 50% 50% repeat-x; font-weight: bold; color: #c77405; }
 .ui-state-hover a, .ui-state-hover a:hover { color: #c77405; text-decoration: none; }
-.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active { border: 1px solid #264b5d; background: #ffffff 50% 50% repeat-x; font-weight: bold; color: #264b5d; }
+.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {display: inline; border: 1px solid #264b5d; background: #ffffff 50% 50% repeat-x; font-weight: bold; color: #264b5d; }
+
 .ui-state-active a, .ui-state-active a:link, .ui-state-active a:visited { color: #eb8f00; text-decoration: none; }
 .ui-widget :active { outline: none; }
 
@@ -115,23 +116,7 @@
  * http://docs.jquery.com/UI/Selectable#theming
  */
 .ui-selectable-helper { position: absolute; z-index: 100; border:1px dotted black; }
-/*
- * jQuery UI Accordion 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Accordion#theming
- */
-/* IE/Win - Fix animation bug - #4615 */
-.ui-accordion { width: 100%; }
-.ui-accordion .ui-accordion-header { cursor: pointer; position: relative; margin-top: 1px; zoom: 1; }
-.ui-accordion .ui-accordion-li-fix { display: inline; }
-.ui-accordion .ui-accordion-header-active { border-bottom: 0 !important; }
-.ui-accordion .ui-accordion-header a { display: block; font-size: 1em; padding: .5em .5em .5em .7em; }
-.ui-accordion .ui-accordion-content { padding: 1em 2.2em; border-top: 0; margin-top: -2px; position: relative; top: 1px; margin-bottom: 2px; overflow: auto; display: none; zoom: 1; }
-.ui-accordion .ui-accordion-content-active { display: block; }
+
 /*
  * jQuery UI Autocomplete 1.8.16
  *
@@ -141,7 +126,12 @@
  *
  * http://docs.jquery.com/UI/Autocomplete#theming
  */
-.ui-autocomplete { text-align: left; position: absolute; cursor: default; }	
+.ui-autocomplete {
+	text-align: left;
+	position: absolute;
+	cursor: default;
+	overflow-x: auto;
+}	
 
 /* workarounds */
 * html .ui-autocomplete { width:1px; } /* without this, the menu expands to 100% in IE6 */
@@ -161,6 +151,8 @@
 	margin: 0;
 	display:block;
 	float: left;
+	white-space: nowrap;
+	padding-bottom: 10px;
 }
 .ui-menu .ui-menu {
 	margin-top: -3px;
@@ -210,143 +202,5 @@ input.ui-button { padding: .4em 1em; }
 
 /* workarounds */
 button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra padding in Firefox */
-/*
- * jQuery UI Dialog 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Dialog#theming
- */
-.ui-dialog { position: absolute; padding: .2em; width: 300px; overflow: hidden; }
-.ui-dialog .ui-dialog-titlebar { padding: .4em 1em; position: relative;  }
-.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 
-.ui-dialog .ui-dialog-titlebar-close { position: absolute; right: .3em; top: 50%; width: 19px; margin: -10px 0 0 0; padding: 1px; height: 18px; }
-.ui-dialog .ui-dialog-titlebar-close span { display: block; margin: 1px; }
-.ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus { padding: 0; }
-.ui-dialog .ui-dialog-content { position: relative; border: 0; padding: .5em 1em; background: none; overflow: auto; zoom: 1; }
-.ui-dialog .ui-dialog-buttonpane { text-align: left; border-width: 1px 0 0 0; background-image: none; margin: .5em 0 0 0; padding: .3em 1em .5em .4em; }
-.ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset { float: right; }
-.ui-dialog .ui-dialog-buttonpane button { margin: .5em .4em .5em 0; cursor: pointer; }
-.ui-dialog .ui-resizable-se { width: 14px; height: 14px; right: 3px; bottom: 3px; }
+
 .ui-draggable .ui-dialog-titlebar { cursor: move; }
-/*
- * jQuery UI Slider 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Slider#theming
- */
-.ui-slider { position: relative; text-align: left; }
-.ui-slider .ui-slider-handle { position: absolute; z-index: 2; width: 1.2em; height: 1.2em; cursor: default; }
-.ui-slider .ui-slider-range { position: absolute; z-index: 1; font-size: .7em; display: block; border: 0; background-position: 0 0; }
-
-.ui-slider-horizontal { height: .8em; }
-.ui-slider-horizontal .ui-slider-handle { top: -.3em; margin-left: -.6em; }
-.ui-slider-horizontal .ui-slider-range { top: 0; height: 100%; }
-.ui-slider-horizontal .ui-slider-range-min { left: 0; }
-.ui-slider-horizontal .ui-slider-range-max { right: 0; }
-
-.ui-slider-vertical { width: .8em; height: 100px; }
-.ui-slider-vertical .ui-slider-handle { left: -.3em; margin-left: 0; margin-bottom: -.6em; }
-.ui-slider-vertical .ui-slider-range { left: 0; width: 100%; }
-.ui-slider-vertical .ui-slider-range-min { bottom: 0; }
-.ui-slider-vertical .ui-slider-range-max { top: 0; }/*
- * jQuery UI Tabs 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Tabs#theming
- */
-.ui-tabs { position: relative; padding: .2em; zoom: 1; } /* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
-.ui-tabs .ui-tabs-nav { margin: 0; padding: .2em .2em 0; }
-.ui-tabs .ui-tabs-nav li { list-style: none; float: left; position: relative; top: 1px; margin: 0 .2em 1px 0; border-bottom: 0 !important; padding: 0; white-space: nowrap; }
-.ui-tabs .ui-tabs-nav li a { float: left; padding: .5em 1em; text-decoration: none; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected { margin-bottom: 0; padding-bottom: 1px; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
-.ui-tabs .ui-tabs-nav li a, .ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a { cursor: pointer; } /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
-.ui-tabs .ui-tabs-panel { display: block; border-width: 0; padding: 1em 1.4em; background: none; }
-.ui-tabs .ui-tabs-hide { display: none !important; }
-/*
- * jQuery UI Datepicker 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Datepicker#theming
- */
-.ui-datepicker { width: 17em; padding: .2em .2em 0; display: none; }
-.ui-datepicker .ui-datepicker-header { position:relative; padding:.2em 0; }
-.ui-datepicker .ui-datepicker-prev, .ui-datepicker .ui-datepicker-next { position:absolute; top: 2px; width: 1.8em; height: 1.8em; }
-.ui-datepicker .ui-datepicker-prev-hover, .ui-datepicker .ui-datepicker-next-hover { top: 1px; }
-.ui-datepicker .ui-datepicker-prev { left:2px; }
-.ui-datepicker .ui-datepicker-next { right:2px; }
-.ui-datepicker .ui-datepicker-prev-hover { left:1px; }
-.ui-datepicker .ui-datepicker-next-hover { right:1px; }
-.ui-datepicker .ui-datepicker-prev span, .ui-datepicker .ui-datepicker-next span { display: block; position: absolute; left: 50%; margin-left: -8px; top: 50%; margin-top: -8px;  }
-.ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
-.ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
-.ui-datepicker select.ui-datepicker-month-year {width: 100%;}
-.ui-datepicker select.ui-datepicker-month, 
-.ui-datepicker select.ui-datepicker-year { width: 49%;}
-.ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
-.ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
-.ui-datepicker td { border: 0; padding: 1px; }
-.ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em; text-align: right; text-decoration: none; }
-.ui-datepicker .ui-datepicker-buttonpane { background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0; }
-.ui-datepicker .ui-datepicker-buttonpane button { float: right; margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
-.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float:left; }
-
-/* with multiple calendars */
-.ui-datepicker.ui-datepicker-multi { width:auto; }
-.ui-datepicker-multi .ui-datepicker-group { float:left; }
-.ui-datepicker-multi .ui-datepicker-group table { width:95%; margin:0 auto .4em; }
-.ui-datepicker-multi-2 .ui-datepicker-group { width:50%; }
-.ui-datepicker-multi-3 .ui-datepicker-group { width:33.3%; }
-.ui-datepicker-multi-4 .ui-datepicker-group { width:25%; }
-.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header { border-left-width:0; }
-.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header { border-left-width:0; }
-.ui-datepicker-multi .ui-datepicker-buttonpane { clear:left; }
-.ui-datepicker-row-break { clear:both; width:100%; font-size:0em; }
-
-/* RTL support */
-.ui-datepicker-rtl { direction: rtl; }
-.ui-datepicker-rtl .ui-datepicker-prev { right: 2px; left: auto; }
-.ui-datepicker-rtl .ui-datepicker-next { left: 2px; right: auto; }
-.ui-datepicker-rtl .ui-datepicker-prev:hover { right: 1px; left: auto; }
-.ui-datepicker-rtl .ui-datepicker-next:hover { left: 1px; right: auto; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane { clear:right; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane button { float: left; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current { float:right; }
-.ui-datepicker-rtl .ui-datepicker-group { float:right; }
-.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
-.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
-
-/* IE6 IFRAME FIX (taken from datepicker 1.5.3 */
-.ui-datepicker-cover {
-    display: none; /*sorry for IE5*/
-    display/**/: block; /*sorry for IE5*/
-    position: absolute; /*must have*/
-    z-index: -1; /*must have*/
-    filter: mask(); /*must have*/
-    top: -4px; /*must have*/
-    left: -4px; /*must have*/
-    width: 200px; /*must have*/
-    height: 200px; /*must have*/
-}/*
- * jQuery UI Progressbar 1.8.16
- *
- * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
- * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
- *
- * http://docs.jquery.com/UI/Progressbar#theming
- */
-.ui-progressbar { height:2em; text-align: left; }
-.ui-progressbar .ui-progressbar-value {margin: -1px; height:100%; }

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-28 01:30+0000\n"
+"POT-Creation-Date: 2023-04-30 06:30+0000\n"
 "PO-Revision-Date: 2023-04-18 06:18+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,43 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:201
+#: helpdesk_proj/settings.py:107 templates/search.html:202
 msgid "English"
 msgstr ""
 
-#: helpdesk_proj/settings.py:108 templates/search.html:203
+#: helpdesk_proj/settings.py:108 templates/search.html:204
 msgid "Spanish"
 msgstr ""
 
-#: templates/search.html:117 templates/search.html:167
+#: templates/search.html:118 templates/search.html:168
 msgid "Category search"
 msgstr ""
 
-#: templates/search.html:128 templates/search.html:178
+#: templates/search.html:129 templates/search.html:179
 msgid "Search"
 msgstr ""
 
-#: templates/search.html:154
+#: templates/search.html:155
 msgid "No results found"
 msgstr ""
 
-#: templates/search.html:155
+#: templates/search.html:156
 msgid "No results 2"
 msgstr "Try calling this number: XXX"
 
-#: templates/search.html:187
+#: templates/search.html:188
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: templates/search.html:206
+#: templates/search.html:207
 msgid "Logout"
 msgstr ""
 
-#: templates/search.html:207
+#: templates/search.html:208
 msgid "Admin Panel"
 msgstr ""
 
-#: templates/search.html:209
+#: templates/search.html:210
 msgid "Staff Login"
 msgstr ""
 

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-27 19:00+0000\n"
+"POT-Creation-Date: 2023-04-27 19:25+0000\n"
 "PO-Revision-Date: 2023-04-18 06:18+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:196
+#: helpdesk_proj/settings.py:107 templates/search.html:197
 msgid "English"
 msgstr ""
 
-#: helpdesk_proj/settings.py:108 templates/search.html:198
+#: helpdesk_proj/settings.py:108 templates/search.html:199
 msgid "Spanish"
 msgstr ""
 
-#: templates/search.html:112 templates/search.html:162
+#: templates/search.html:112 templates/search.html:163
 msgid "Category search"
 msgstr ""
 
-#: templates/search.html:123 templates/search.html:173
+#: templates/search.html:123 templates/search.html:174
 msgid "Search"
 msgstr ""
 
@@ -43,19 +43,19 @@ msgstr ""
 msgid "No results 2"
 msgstr "Try calling this number: XXX"
 
-#: templates/search.html:182
+#: templates/search.html:183
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: templates/search.html:201
+#: templates/search.html:202
 msgid "Logout"
 msgstr ""
 
-#: templates/search.html:202
+#: templates/search.html:203
 msgid "Admin Panel"
 msgstr ""
 
-#: templates/search.html:204
+#: templates/search.html:205
 msgid "Staff Login"
 msgstr ""
 

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-27 19:25+0000\n"
+"POT-Creation-Date: 2023-04-28 01:30+0000\n"
 "PO-Revision-Date: 2023-04-18 06:18+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,43 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:197
+#: helpdesk_proj/settings.py:107 templates/search.html:201
 msgid "English"
 msgstr ""
 
-#: helpdesk_proj/settings.py:108 templates/search.html:199
+#: helpdesk_proj/settings.py:108 templates/search.html:203
 msgid "Spanish"
 msgstr ""
 
-#: templates/search.html:112 templates/search.html:163
+#: templates/search.html:117 templates/search.html:167
 msgid "Category search"
 msgstr ""
 
-#: templates/search.html:123 templates/search.html:174
+#: templates/search.html:128 templates/search.html:178
 msgid "Search"
 msgstr ""
 
-#: templates/search.html:149
+#: templates/search.html:154
 msgid "No results found"
 msgstr ""
 
-#: templates/search.html:150
+#: templates/search.html:155
 msgid "No results 2"
 msgstr "Try calling this number: XXX"
 
-#: templates/search.html:183
+#: templates/search.html:187
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: templates/search.html:202
+#: templates/search.html:206
 msgid "Logout"
 msgstr ""
 
-#: templates/search.html:203
+#: templates/search.html:207
 msgid "Admin Panel"
 msgstr ""
 
-#: templates/search.html:205
+#: templates/search.html:209
 msgid "Staff Login"
 msgstr ""
 

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-25 03:30+0000\n"
+"POT-Creation-Date: 2023-04-27 19:00+0000\n"
 "PO-Revision-Date: 2023-04-18 06:18+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,46 +19,44 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:105 templates/search.html:123
-#: templates/search.html:166
+#: helpdesk_proj/settings.py:107 templates/search.html:196
 msgid "English"
 msgstr ""
 
-#: helpdesk_proj/settings.py:106 templates/search.html:125
-#: templates/search.html:168
+#: helpdesk_proj/settings.py:108 templates/search.html:198
 msgid "Spanish"
 msgstr ""
 
-#: templates/search.html:99 templates/search.html:180
+#: templates/search.html:112 templates/search.html:162
 msgid "Category search"
 msgstr ""
 
-#: templates/search.html:110 templates/search.html:190
+#: templates/search.html:123 templates/search.html:173
 msgid "Search"
-msgstr ""
-
-#: templates/search.html:117 templates/search.html:160
-msgid "Logout"
-msgstr ""
-
-#: templates/search.html:118 templates/search.html:161
-msgid "Admin Panel"
-msgstr ""
-
-#: templates/search.html:120 templates/search.html:163
-msgid "Staff Login"
 msgstr ""
 
 #: templates/search.html:149
 msgid "No results found"
 msgstr ""
 
-#: templates/search.html:151
+#: templates/search.html:150
 msgid "No results 2"
 msgstr "Try calling this number: XXX"
 
-#: templates/search.html:199
+#: templates/search.html:182
 msgid "Frequently Asked Questions"
+msgstr ""
+
+#: templates/search.html:201
+msgid "Logout"
+msgstr ""
+
+#: templates/search.html:202
+msgid "Admin Panel"
+msgstr ""
+
+#: templates/search.html:204
+msgid "Staff Login"
 msgstr ""
 
 #~ msgid "Test"

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-25 03:30+0000\n"
+"POT-Creation-Date: 2023-04-27 19:01+0000\n"
 "PO-Revision-Date: 2023-04-25 03:31+0000\n"
 "Last-Translator:   <admin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,47 +19,45 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:105 templates/search.html:123
-#: templates/search.html:166
+#: helpdesk_proj/settings.py:107 templates/search.html:196
 msgid "English"
 msgstr "Inglés"
 
-#: helpdesk_proj/settings.py:106 templates/search.html:125
-#: templates/search.html:168
+#: helpdesk_proj/settings.py:108 templates/search.html:198
 msgid "Spanish"
 msgstr "Español"
 
-#: templates/search.html:99 templates/search.html:180
+#: templates/search.html:112 templates/search.html:162
 msgid "Category search"
 msgstr "Categoría"
 
-#: templates/search.html:110 templates/search.html:190
+#: templates/search.html:123 templates/search.html:173
 msgid "Search"
 msgstr "Buscar"
-
-#: templates/search.html:117 templates/search.html:160
-msgid "Logout"
-msgstr "Cerrar sesión"
-
-#: templates/search.html:118 templates/search.html:161
-msgid "Admin Panel"
-msgstr "Administrador"
-
-#: templates/search.html:120 templates/search.html:163
-msgid "Staff Login"
-msgstr "Inicio de sesión de administrador"
 
 #: templates/search.html:149
 msgid "No results found"
 msgstr "No se han encontrado resultados"
 
-#: templates/search.html:151
+#: templates/search.html:150
 msgid "No results 2"
 msgstr "Intenta llamar a XXX"
 
-#: templates/search.html:199
+#: templates/search.html:182
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
+
+#: templates/search.html:201
+msgid "Logout"
+msgstr "Cerrar sesión"
+
+#: templates/search.html:202
+msgid "Admin Panel"
+msgstr "Administrador"
+
+#: templates/search.html:204
+msgid "Staff Login"
+msgstr "Inicio de sesión de administrador"
 
 #~ msgid "Language"
 #~ msgstr "Idioma"

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-27 19:01+0000\n"
+"POT-Creation-Date: 2023-04-27 19:25+0000\n"
 "PO-Revision-Date: 2023-04-25 03:31+0000\n"
 "Last-Translator:   <admin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:196
+#: helpdesk_proj/settings.py:107 templates/search.html:197
 msgid "English"
 msgstr "Inglés"
 
-#: helpdesk_proj/settings.py:108 templates/search.html:198
+#: helpdesk_proj/settings.py:108 templates/search.html:199
 msgid "Spanish"
 msgstr "Español"
 
-#: templates/search.html:112 templates/search.html:162
+#: templates/search.html:112 templates/search.html:163
 msgid "Category search"
 msgstr "Categoría"
 
-#: templates/search.html:123 templates/search.html:173
+#: templates/search.html:123 templates/search.html:174
 msgid "Search"
 msgstr "Buscar"
 
@@ -43,19 +43,19 @@ msgstr "No se han encontrado resultados"
 msgid "No results 2"
 msgstr "Intenta llamar a XXX"
 
-#: templates/search.html:182
+#: templates/search.html:183
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: templates/search.html:201
+#: templates/search.html:202
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: templates/search.html:202
+#: templates/search.html:203
 msgid "Admin Panel"
 msgstr "Administrador"
 
-#: templates/search.html:204
+#: templates/search.html:205
 msgid "Staff Login"
 msgstr "Inicio de sesión de administrador"
 

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-28 01:30+0000\n"
+"POT-Creation-Date: 2023-04-30 06:30+0000\n"
 "PO-Revision-Date: 2023-04-25 03:31+0000\n"
 "Last-Translator:   <admin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,43 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:201
+#: helpdesk_proj/settings.py:107 templates/search.html:202
 msgid "English"
 msgstr "Inglés"
 
-#: helpdesk_proj/settings.py:108 templates/search.html:203
+#: helpdesk_proj/settings.py:108 templates/search.html:204
 msgid "Spanish"
 msgstr "Español"
 
-#: templates/search.html:117 templates/search.html:167
+#: templates/search.html:118 templates/search.html:168
 msgid "Category search"
 msgstr "Categoría"
 
-#: templates/search.html:128 templates/search.html:178
+#: templates/search.html:129 templates/search.html:179
 msgid "Search"
 msgstr "Buscar"
 
-#: templates/search.html:154
+#: templates/search.html:155
 msgid "No results found"
 msgstr "No se han encontrado resultados"
 
-#: templates/search.html:155
+#: templates/search.html:156
 msgid "No results 2"
 msgstr "Intenta llamar a XXX"
 
-#: templates/search.html:187
+#: templates/search.html:188
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: templates/search.html:206
+#: templates/search.html:207
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: templates/search.html:207
+#: templates/search.html:208
 msgid "Admin Panel"
 msgstr "Administrador"
 
-#: templates/search.html:209
+#: templates/search.html:210
 msgid "Staff Login"
 msgstr "Inicio de sesión de administrador"
 

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-27 19:25+0000\n"
+"POT-Creation-Date: 2023-04-28 01:30+0000\n"
 "PO-Revision-Date: 2023-04-25 03:31+0000\n"
 "Last-Translator:   <admin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,43 +19,43 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:197
+#: helpdesk_proj/settings.py:107 templates/search.html:201
 msgid "English"
 msgstr "Inglés"
 
-#: helpdesk_proj/settings.py:108 templates/search.html:199
+#: helpdesk_proj/settings.py:108 templates/search.html:203
 msgid "Spanish"
 msgstr "Español"
 
-#: templates/search.html:112 templates/search.html:163
+#: templates/search.html:117 templates/search.html:167
 msgid "Category search"
 msgstr "Categoría"
 
-#: templates/search.html:123 templates/search.html:174
+#: templates/search.html:128 templates/search.html:178
 msgid "Search"
 msgstr "Buscar"
 
-#: templates/search.html:149
+#: templates/search.html:154
 msgid "No results found"
 msgstr "No se han encontrado resultados"
 
-#: templates/search.html:150
+#: templates/search.html:155
 msgid "No results 2"
 msgstr "Intenta llamar a XXX"
 
-#: templates/search.html:183
+#: templates/search.html:187
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: templates/search.html:202
+#: templates/search.html:206
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: templates/search.html:203
+#: templates/search.html:207
 msgid "Admin Panel"
 msgstr "Administrador"
 
-#: templates/search.html:205
+#: templates/search.html:209
 msgid "Staff Login"
 msgstr "Inicio de sesión de administrador"
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -50,6 +50,20 @@
         <!-- autocomplete / FAQ script -->
         <script>
             $( function() {
+                var getOptions = function (request, response) {
+                    // get the selected category
+                    var categories_elements = document.getElementsByClassName("search_category");
+                    var selected_category = categories_elements[0].options[categories_elements[0].selectedIndex].text;
+                    $.getJSON(
+                        // build autocomplete query
+                        '{% url "autocomplete" %}' + "?term=" +request.term + "&c=" + selected_category,
+                        function (data) {
+                            return response(data);
+                        });
+                };
+                // using the autocomplete widget, getOptions is called when the user types into the search bar
+
+            } );
                 $( "#tags" ).autocomplete({
                     source: '{% url "autocomplete" %}',
                     minlength: 1
@@ -82,7 +96,6 @@
                         }
                     });
                 });
-            });
         </script>
     </head>
     {% get_current_language as CURRENT_LANGUAGE %}

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -53,7 +53,8 @@
                 var getOptions = function (request, response) {
                     // get the selected category
                     var categories_elements = document.getElementsByClassName("search_category");
-                    var selected_category = categories_elements[0].options[categories_elements[0].selectedIndex].text;
+                    var selected_category = categories_elements[0].options[categories_elements[0].selectedIndex].value;
+                    console.log(selected_category)
                     $.getJSON(
                         // build autocomplete query
                         '{% url "autocomplete" %}' + "?term=" +request.term + "&c=" + selected_category,

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -62,11 +62,14 @@
                         });
                 };
                 // using the autocomplete widget, getOptions is called when the user types into the search bar
-
-            } );
                 $( "#tags" ).autocomplete({
-                    source: '{% url "autocomplete" %}',
-                    minlength: 1
+                    source: getOptions,
+                    minlength: 1,
+
+                    //set width of autcomplete result box to the width of the search bar
+                    open: function() {
+                        $("ul.ui-menu").width( $(this).innerWidth() );
+                    }
                 });
 
                 $( "#main-category-select" ).on('change', function() {
@@ -96,6 +99,8 @@
                         }
                     });
                 });
+            } );
+
         </script>
     </head>
     {% get_current_language as CURRENT_LANGUAGE %}

--- a/src/tests/test_autocomplete.py
+++ b/src/tests/test_autocomplete.py
@@ -87,15 +87,29 @@ class AutocompleteTests(TestCase):
         # Same as making a GET request to '/autocomplete')
         response = autocomplete_search(request)
         decoded_response = str(response.content.decode('utf-8').rstrip().split('\n'))
-
         # Ensure a response was returned
         self.assertEquals(decoded_response.find("No results found"), -1)
         # Ensure the right resource was returned by the model
-        self.assertNotEqual(decoded_response.find("How to Properly Restart a Router and Modem"), -1)
+        self.assertNotEqual(decoded_response.find("How to Properly Restart a Router"), -1)
 
     def test_autocomplete_no_result(self):
         # Prepare request object
         request = self.factory.get('/autocomplete?term=random')
+        request.user = self.user
+        # Necessary as messages and session middleware are not instantiated in test environments
+        setattr(request, 'session', 'session')
+        setattr(request, '_messages', FallbackStorage(request))
+
+        # Same as making a GET request to '/autocomplete')
+        response = autocomplete_search(request)
+        decoded_response = ''.join(filter(str.isalnum, str(response.content.decode('utf-8').rstrip().split('\n'))))
+
+        # Ensure a response was NOT returned
+        self.assertEqual(decoded_response, "")
+
+    def test_autocomplete_different_category_no_result(self):
+        # Prepare request object
+        request = self.factory.get('/autocomplete?term=restart&c=Category1')
         request.user = self.user
         # Necessary as messages and session middleware are not instantiated in test environments
         setattr(request, 'session', 'session')


### PR DESCRIPTION
This PR fixes #67 and #74. Now, the only autocomplete results that show up are ones under the selected category.
<img width="935" alt="Screen Shot 2023-04-27 at 9 59 37 PM" src="https://user-images.githubusercontent.com/20130977/235036246-b9acb03c-b3ea-479a-a24e-0943203f606f.png">
<img width="723" alt="Screen Shot 2023-04-27 at 10 00 03 PM" src="https://user-images.githubusercontent.com/20130977/235036291-f6d81c46-8c2b-45f9-ba03-4ea845784285.png">
If no category is selected the results are pulled from all categories.

The box for the autocomplete results now expands to the width of the search bar. If the autocomplete result title is longer, a horizontal scroll bar will appear for users to see the whole title without the title being overwhelming and taking up too much screen space.
<img width="780" alt="Screen Shot 2023-04-27 at 10 03 17 PM" src="https://user-images.githubusercontent.com/20130977/235036679-317369c0-1d25-47ac-9837-f5e0523da576.png">

