### PR TITLE
[M5] Moved search button on home page (fixes #80)

### DIFF
--- a/src/helpdesk_proj/static/helpdesk_app/css/search.css
+++ b/src/helpdesk_proj/static/helpdesk_app/css/search.css
@@ -83,6 +83,13 @@ li a:hover {
     align-content: center;
 }
 
+.search_section {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+}
+
+
 .bar {
     display: flex;
     margin: 1%;
@@ -91,6 +98,10 @@ li a:hover {
     border-radius:30px;
     border:1px solid #3950A2;
     align-items: center;
+}
+
+.buttons {
+    margin: 1%;
 }
 
 .bar:hover{

--- a/src/locale/en/LC_MESSAGES/django.po
+++ b/src/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-30 06:30+0000\n"
+"POT-Creation-Date: 2023-04-30 07:28+0000\n"
 "PO-Revision-Date: 2023-04-18 06:18+0000\n"
 "Last-Translator:   <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:202
+#: helpdesk_proj/settings.py:110 templates/search.html:204
 msgid "English"
 msgstr ""
 
-#: helpdesk_proj/settings.py:108 templates/search.html:204
+#: helpdesk_proj/settings.py:111 templates/search.html:206
 msgid "Spanish"
 msgstr ""
 
-#: templates/search.html:118 templates/search.html:168
+#: templates/search.html:118 templates/search.html:169
 msgid "Category search"
 msgstr ""
 
-#: templates/search.html:129 templates/search.html:179
+#: templates/search.html:129 templates/search.html:180
 msgid "Search"
 msgstr ""
 
@@ -43,19 +43,19 @@ msgstr ""
 msgid "No results 2"
 msgstr "Try calling this number: XXX"
 
-#: templates/search.html:188
+#: templates/search.html:190
 msgid "Frequently Asked Questions"
 msgstr ""
 
-#: templates/search.html:207
+#: templates/search.html:209
 msgid "Logout"
 msgstr ""
 
-#: templates/search.html:208
+#: templates/search.html:210
 msgid "Admin Panel"
 msgstr ""
 
-#: templates/search.html:210
+#: templates/search.html:212
 msgid "Staff Login"
 msgstr ""
 

--- a/src/locale/es/LC_MESSAGES/django.po
+++ b/src/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-30 06:30+0000\n"
+"POT-Creation-Date: 2023-04-30 07:28+0000\n"
 "PO-Revision-Date: 2023-04-25 03:31+0000\n"
 "Last-Translator:   <admin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,19 +19,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Translated-Using: django-rosetta 0.9.8\n"
 
-#: helpdesk_proj/settings.py:107 templates/search.html:202
+#: helpdesk_proj/settings.py:110 templates/search.html:204
 msgid "English"
 msgstr "Inglés"
 
-#: helpdesk_proj/settings.py:108 templates/search.html:204
+#: helpdesk_proj/settings.py:111 templates/search.html:206
 msgid "Spanish"
 msgstr "Español"
 
-#: templates/search.html:118 templates/search.html:168
+#: templates/search.html:118 templates/search.html:169
 msgid "Category search"
 msgstr "Categoría"
 
-#: templates/search.html:129 templates/search.html:179
+#: templates/search.html:129 templates/search.html:180
 msgid "Search"
 msgstr "Buscar"
 
@@ -43,19 +43,19 @@ msgstr "No se han encontrado resultados"
 msgid "No results 2"
 msgstr "Intenta llamar a XXX"
 
-#: templates/search.html:188
+#: templates/search.html:190
 msgid "Frequently Asked Questions"
 msgstr "Preguntas Frecuentes"
 
-#: templates/search.html:207
+#: templates/search.html:209
 msgid "Logout"
 msgstr "Cerrar sesión"
 
-#: templates/search.html:208
+#: templates/search.html:210
 msgid "Admin Panel"
 msgstr "Administrador"
 
-#: templates/search.html:210
+#: templates/search.html:212
 msgid "Staff Login"
 msgstr "Inicio de sesión de administrador"
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -67,7 +67,7 @@
                     source: getOptions,
                     minlength: 1,
 
-                    //set width of autcomplete result box to the width of the search bar
+                    // set width of autcomplete result box to the width of the search bar
                     open: function() {
                         $("ul.ui-menu").width( $(this).innerWidth() );
                     }
@@ -163,20 +163,22 @@
             <center>
             <img alt="Logo" class="logo" src="{% static 'helpdesk_app/img/logo.png' %}">
             <form action="{% url 'search' %}" method="get">
-                <div class="bar">
-                    <select class="search_category" name="c" id="main-category-select">
-                        <option value="">{% trans "Category search" %}</option>
-                        {% for category in categories %}
-                            <option value="{{ category.category_name }}">
-                            {{ category }}
-                            </option>
-                        {% endfor %}
-                    </select>
-                    <input id="tags" class="searchbar" type="text" title="Search" name="q">
-                </div>
-                <br/>
-                <div class="buttons">
-                    <input class="button" type="submit" value="{% trans 'Search' %}"></input>
+                <div class="search_section">
+                    <div class="bar">
+                        <select class="search_category" name="c" id="main-category-select">
+                            <option value="">{% trans "Category search" %}</option>
+                            {% for category in categories %}
+                                <option value="{{ category.category_name }}">
+                                {{ category }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        <input id="tags" class="searchbar" type="text" title="Search" name="q">
+                    </div>
+                    <br/>
+                    <div class="buttons">
+                        <input class="button" type="submit" value="{% trans 'Search' %}"></input>
+                    </div>
                 </div>
             </form>
             </center>


### PR DESCRIPTION
The search button is now moved to the right side of the search bar instead of below it. Now, autocomplete results do not cover the search button. (fixes #80)
<img width="969" alt="Screen Shot 2023-04-30 at 1 35 33 PM" src="https://user-images.githubusercontent.com/20130977/235367674-ef1d3eeb-3bc5-4fc4-bbe8-65ee83bc3f02.png">
