### PR TITLE
[M5] Search query edge cases handled (fixes #84)

### DIFF
--- a/src/Pipfile
+++ b/src/Pipfile
@@ -53,7 +53,6 @@ wrapt = "==1.11.1"
 django-widget-tweaks = "==1.4.12"
 python-gettext = "*"
 django-rosetta = "==0.9.8"
-re = "3.11.3"
 
 [dev-packages]
 flake8 = "*"

--- a/src/Pipfile
+++ b/src/Pipfile
@@ -53,6 +53,7 @@ wrapt = "==1.11.1"
 django-widget-tweaks = "==1.4.12"
 python-gettext = "*"
 django-rosetta = "==0.9.8"
+re = "3.11.3"
 
 [dev-packages]
 flake8 = "*"

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -15,7 +15,6 @@ from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
 from bs4 import BeautifulSoup
 import requests
-import re
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from helpdesk_app.models import AnswerResource

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -15,6 +15,7 @@ from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
 from bs4 import BeautifulSoup
 import requests
+import re
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from helpdesk_app.models import AnswerResource
@@ -27,12 +28,15 @@ nltk.download('wordnet')
 # Error message from browser when webscraping fails
 ERROR_MESSAGE = "Acceptable ! appropriate representation requested resource could found server . error generated Mod_Security ."
 # Determines how much the key words matter when searching links
-KEYWORD_WIEGHT = 2
+KEYWORD_WEIGHT = 2
 # Determines how many results should be returned
 SEARCH_LIST_LEN = 5
 # There are two methods of finding search results, use the tags matching built-in functionality or cosine similarity developed
 # in this class, this variable determines which method to use. (In development for now)
 USE_TAGS = False
+# Used for regex cleaning of input, all non-alphanumeric characters are removed expected these, the underlying algorithm for getting
+# search results has trouble with some characters so most most non-alphanumberic characters are remoed
+CHARACTERS_TO_KEEP_LIST = " /\\?!@#$%&*();,.:"
 
 
 class WebpageSearcher:
@@ -68,7 +72,6 @@ class WebpageSearcher:
     def search(self, query, category_object):
         # Use natural language processing to process the query
         processed_query = preprocess_text(query)
-
         if (processed_query is None or processed_query == ''):
             return []
 
@@ -90,7 +93,7 @@ class WebpageSearcher:
             for link in self.links:
                 processed_link = link.content
                 keywords = " ".join(link.tags.names())
-                similarity = (calculate_similarity(processed_query, processed_link) + calculate_similarity(processed_query, keywords) * KEYWORD_WIEGHT)
+                similarity = (calculate_similarity(processed_query, processed_link) + calculate_similarity(processed_query, keywords) * KEYWORD_WEIGHT)
                 if (similarity > 0):
                     similarities[link] = similarity
 
@@ -109,11 +112,18 @@ class WebpageSearcher:
 
 
 def preprocess_text(text):
+    # clean input with regex
+    text = re.sub(r'[^\w' + CHARACTERS_TO_KEEP_LIST + ']', '', text)
+
     # Tokenize the text into words
     words = nltk.word_tokenize(text)
-
     # Remove stopwords
     stopwords_list = stopwords.words('english')
+
+    # add all singlular charcters to stopwords list
+    for i in range(33, 127):
+        stopwords_list.append(chr(i))
+
     filtered_words = [word for word in words if word.lower() not in stopwords_list]
 
     # Lemmatize the words

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -36,7 +36,7 @@ SEARCH_LIST_LEN = 5
 USE_TAGS = False
 # Used for regex cleaning of input, all non-alphanumeric characters are removed expected these, the underlying algorithm for getting
 # search results has trouble with some characters so most most non-alphanumberic characters are remoed
-CHARACTERS_TO_KEEP_LIST = " /\\?!@#$%&*();,.:"
+CHARACTERS_TO_KEEP_LIST = " ?!@#$%&()."
 
 
 class WebpageSearcher:

--- a/src/SearchEngine/WebpageSearcher.py
+++ b/src/SearchEngine/WebpageSearcher.py
@@ -19,6 +19,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from helpdesk_app.models import AnswerResource
 from django.db.utils import OperationalError
+import re
 
 nltk.download('punkt')
 nltk.download('stopwords')

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -107,3 +107,18 @@ class SearchTests(TestCase):
         
         # Ensure a response was NOT returned
         self.assertNotEqual(decoded_response.find("No results found"), -1)
+
+    def test_search_special_characters_no_results(self):
+        # Prepare request object
+        request = self.factory.get('/search?q=\" ^ \' - +  ^^ \'\' -- ++')
+        request.user = self.user
+        # Necessary as messages and session middleware are not instantiated in test environments
+        setattr(request, 'session', 'session')
+        setattr(request, '_messages', FallbackStorage(request))
+        
+        # Same as making a GET request to '/search')
+        response = search(request)
+        decoded_response = str(response.content.decode('utf-8').rstrip().split('\n'))
+        
+        # Ensure a response was NOT returned
+        self.assertNotEqual(decoded_response.find("No results found"), -1)


### PR DESCRIPTION
Handles edge cases for when certain characters are in the query. Described more in #84 (fixes #84).
For example:
<img width="1655" alt="Screen Shot 2023-04-30 at 2 53 36 PM" src="https://user-images.githubusercontent.com/20130977/235371167-537e1e61-8a1e-43ff-9026-eb67e2a506e4.png">
This would have returned a ValueError previously. 